### PR TITLE
Add validated subscription domain model (closes #5)

### DIFF
--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field, EmailStr
+
+
+class Subscription(BaseModel):
+    location_name: str = Field(..., min_length=1, max_length=100)
+    latitude: float = Field(..., ge=-90, le=90)
+    longitude: float = Field(..., ge=-180, le=180)
+    notification_target: EmailStr
+    lead_time_minutes: int = Field(default=10, ge=1, le=1440)

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,9 +1,22 @@
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import BaseModel, Field, EmailStr, field_validator
 
 
 class Subscription(BaseModel):
+    """
+    Validated input schema for subscription requests that drive
+    orbital event ingestion and notification workflows.
+    """
+
     location_name: str = Field(..., min_length=1, max_length=100)
     latitude: float = Field(..., ge=-90, le=90)
     longitude: float = Field(..., ge=-180, le=180)
     notification_target: EmailStr
     lead_time_minutes: int = Field(default=10, ge=1, le=1440)
+
+    @field_validator("location_name")
+    @classmethod
+    def strip_location(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("location_name cannot be empty")
+        return v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,15 @@
+[project]
+dependencies = [
+    "pydantic[email]>=2.0",
+    # ...other deps
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
 [tool.fastapi]
 entrypoint = "app.main:app"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tests/test_subscription_model.py
+++ b/tests/test_subscription_model.py
@@ -1,0 +1,78 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models.subscription import Subscription
+
+
+def test_valid_subscription_model():
+    subscription = Subscription(
+        location_name="Henderson, NV",
+        latitude=36.0395,
+        longitude=-114.9817,
+        notification_target="nigel@example.com",
+        lead_time_minutes=10,
+    )
+
+    assert subscription.location_name == "Henderson, NV"
+    assert subscription.latitude == 36.0395
+    assert subscription.longitude == -114.9817
+    assert subscription.notification_target == "nigel@example.com"
+    assert subscription.lead_time_minutes == 10
+
+
+@pytest.mark.parametrize("latitude", [-91, 91])
+def test_subscription_rejects_invalid_latitude(latitude):
+    with pytest.raises(ValidationError):
+        Subscription(
+            location_name="Invalid Latitude",
+            latitude=latitude,
+            longitude=-114.9817,
+            notification_target="nigel@example.com",
+            lead_time_minutes=10,
+        )
+
+
+@pytest.mark.parametrize("longitude", [-181, 181])
+def test_subscription_rejects_invalid_longitude(longitude):
+    with pytest.raises(ValidationError):
+        Subscription(
+            location_name="Invalid Longitude",
+            latitude=36.0395,
+            longitude=longitude,
+            notification_target="nigel@example.com",
+            lead_time_minutes=10,
+        )
+
+
+@pytest.mark.parametrize("lead_time", [0, -1, 1441])
+def test_subscription_rejects_invalid_lead_time(lead_time):
+    with pytest.raises(ValidationError):
+        Subscription(
+            location_name="Invalid Lead Time",
+            latitude=36.0395,
+            longitude=-114.9817,
+            notification_target="nigel@example.com",
+            lead_time_minutes=lead_time,
+        )
+
+
+def test_subscription_rejects_invalid_notification_target():
+    with pytest.raises(ValidationError):
+        Subscription(
+            location_name="Invalid Email",
+            latitude=36.0395,
+            longitude=-114.9817,
+            notification_target="not-an-email",
+            lead_time_minutes=10,
+        )
+
+
+def test_subscription_rejects_empty_location_name():
+    with pytest.raises(ValidationError):
+        Subscription(
+            location_name="",
+            latitude=36.0395,
+            longitude=-114.9817,
+            notification_target="nigel@example.com",
+            lead_time_minutes=10,
+        )

--- a/tests/test_subscription_model.py
+++ b/tests/test_subscription_model.py
@@ -76,3 +76,14 @@ def test_subscription_rejects_empty_location_name():
             notification_target="nigel@example.com",
             lead_time_minutes=10,
         )
+
+
+def test_subscription_strips_location_name():
+    s = Subscription(
+        location_name="  Henderson, NV  ",
+        latitude=36.0395,
+        longitude=-114.9817,
+        notification_target="nigel@example.com",
+        lead_time_minutes=10,
+    )
+    assert s.location_name == "Henderson, NV"


### PR DESCRIPTION
## Summary
- Added a validated Subscription domain model
- Added validation for location name, latitude, longitude, notification target, and lead time
- Added tests for valid and invalid subscription inputs

## Why
This establishes a clean input schema for future orbital event ingestion and notification workflows.

## Test
- python -m pytest